### PR TITLE
reduce file size

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -9,14 +9,24 @@ remappings = [
     'seadrop/=src/',
 ]
 optimizer = true
-optimizer_runs = 200
+optimizer_runs = 1_000_000
 via_ir = true
 ignored_error_codes = []
 bytecode_hash = "none"
 bytecode_metadata = "none"
 
-[profile.upgradeable]
-src = 'src-upgradeable/src/'
+# for now, we need to construct additional profiles manually
+# cf. https://github.com/foundry-rs/foundry/pull/8668
+additional_compiler_profiles = [
+    { name = "default", optimizer_runs = 1_000_000 },
+    { name = "runs_100", optimizer_runs = 100 }
+]
+
+# Some optimizer runs may be reduced below the specified max_optimizer_runs
+# during testing due to combined restrictions.
+compilation_restrictions = [
+    { paths = "src-upgradeable/src/Imprint.sol", max_optimizer_runs = 100 }
+]
 
 [profile.ir_inspect]
 test = 'src'
@@ -24,5 +34,3 @@ test = 'src'
 [rpc_endpoints]
 goerli = '${GOERLI_RPC_URL}'
 mainnet = '${ETHEREUM_RPC_URL}'
-
-# See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/src-upgradeable/src/Imprint.sol
+++ b/src-upgradeable/src/Imprint.sol
@@ -2,116 +2,22 @@
 pragma solidity 0.8.17;
 
 import { ERC721SeaDropUpgradeable } from "./ERC721SeaDropUpgradeable.sol";
-import { SSTORE2 } from "../lib-upgradeable/solmate/src/utils/SSTORE2.sol";
 import {INonFungibleSeaDropTokenUpgradeable} from "./interfaces/INonFungibleSeaDropTokenUpgradeable.sol";
 import {ISeaDropTokenContractMetadataUpgradeable} from "./interfaces/ISeaDropTokenContractMetadataUpgradeable.sol";
 import { IImprintDescriptor } from "./interfaces/IImprintDescriptor.sol";
-
-/// Interface for Subject contract
-interface ISubject {
-    function syncFromImprint(string calldata subjectName, uint256 imprintId, uint64 ts) external;
-}
-
-/// ──────────────────────────────────────────────────────────────
-///  ImprintStorage  ── World Canon / Imprint  固定ストレージ
-/// ──────────────────────────────────────────────────────────────
-library ImprintStorage {
-    /*═════════ ① 不変データ構造 ═════════*/
-
-    /// Edition 毎のヘッダー
-    struct EditionHeader {
-        uint64  editionNo;   // 連番（＝キー）
-        string  model;       // 例 "GPT-4o"
-        uint64  timestamp;   // block.timestamp (UTC 秒)
-        bool    isSealed;      // true なら Seed 追加不可
-    }
-
-    /// SeaDrop ミント前にプレ登録する “Seed”
-    struct ImprintSeed {
-        uint64   editionNo;      // 紐づく Edition
-        uint16   localIndex;     // Edition 内 index
-        uint256  subjectId;      // Subject tokenId
-        string   subjectName;    // Subject 名
-        address  descPtr;        // SSTORE2 ポインタ
-        bool     claimed;        // mint 済みか
-    }
-
-    /// Mint 後、Subject 側から呼ばれるときに使う最終メタ
-    struct TokenMeta {
-        uint64  editionNo;
-        uint16  localIndex;      // Edition 内 index
-        string  model;
-        string  subjectName;
-    }
-
-    /*═════════ ② Diamond-Layout ═════════*/
-
-    struct Layout {
-        /* --- Finalized Imprint (tokenId 同値) --- */
-        mapping(uint256 => address)     descPtr;   // slot offset 0
-        mapping(uint256 => TokenMeta)   meta;      // slot offset 1
-
-        /* --- Edition & Seed --- */
-        mapping(uint64  => EditionHeader) editionHeaders;   // slot offset 2
-        mapping(uint256 => ImprintSeed)   seeds;            // slot offset 3
-        uint256  nextSeedId;                                // slot offset 4
-
-        /* --- Sale --- */
-        uint64  activeEdition;       // 現在販売中の Edition
-        uint256 activeCursor;        // その Edition 内で次に配布する seedId
-        mapping(uint64 => uint256) firstSeedId;   // editionNo -> 先頭 seedId
-        mapping(uint64 => uint256) lastSeedId;    // editionNo -> 末尾 seedId
-        mapping(uint64 => mapping(uint16 => bool)) localIndexTaken;
-
-        /* --- Globals --- */
-        address  worldCanon;   // Subject コントラクト (set once)
-        bool     mintPaused;   // Mint一時停止フラグ
-    }
-
-    /*═════════ ③ 取得ヘルパ ═════════*/
-
-    bytes32 internal constant STORAGE_SLOT =
-        keccak256("worldcanon.imprint.storage.v0");
-
-    function layout() internal pure returns (Layout storage l) {
-        bytes32 slot = STORAGE_SLOT;
-        assembly { l.slot := slot }
-    }
-}
-
-/// @dev owner が Seed を一括登録するときに使う入力フォーマット
-struct SeedInput {
-    uint64  editionNo;      // 紐づく Edition
-    uint16  localIndex;     // Edition 内の連番
-    uint256 subjectId;      // Subject tokenId（まだ使わなければ 0 でも可）
-    string  subjectName;    // 表示用名
-    bytes   desc;           // SVG 本文（UTF-8）最大 280Byte 推奨
-}
-
-// Custom errors for gas optimization
-error ZeroAddress();
-error InvalidEditionNo();
-error EmptyModel();
-error EditionExists();
-error UnknownEdition();
-error AlreadySealed();
-error EmptyInput();
-error MixedEdition();
-error EmptyDesc();
-error EditionMissing();
-error EditionAlreadySealed();
-error DuplicateLocalIdx();
-error EditionNotSealed();
-error NoSeeds();
-error MintingPaused();
-error NoActiveEdition();
-error SoldOut();
-error TokenNonexistent();
-error DescriptorUnset();
-error DescriptorFail();
-error WorldCanonAlreadySet();
-error DescMissing();
-error MetaMissing();
+import { 
+    ImprintLib, 
+    SeedInput, 
+    ImprintStorage, 
+    ZeroAddress,
+    MintingPaused,
+    NoActiveEdition,
+    SoldOut,
+    TokenNonexistent,
+    DescriptorUnset,
+    DescriptorFail,
+    WorldCanonAlreadySet
+} from "./ImprintLib.sol";
 
 /*
  * @notice This contract uses ERC721SeaDrop,
@@ -121,20 +27,12 @@ error MetaMissing();
 contract Imprint is ERC721SeaDropUpgradeable {
     using ImprintStorage for ImprintStorage.Layout;
 
-
-    /* ──────────────── events ──────────────── */
-    event EditionCreated(uint64 indexed editionNo, string model, uint64 timestamp);
-    event EditionSealed(uint64 indexed editionNo);
-    event ActiveEditionChanged(uint64 indexed newEdition);
-    event WorldCanonSet(address indexed worldCanon);
-
     /* ──────────────── init ──────────────── */
     function __Imprint_init(
         string memory name,
         string memory symbol,
         address[] memory allowedSeaDrop
     ) internal onlyInitializing {
-        // Initialize ERC721SeaDrop with name, symbol, and allowed SeaDrop
         __ERC721SeaDrop_init(name, symbol, allowedSeaDrop);
     }
 
@@ -146,216 +44,54 @@ contract Imprint is ERC721SeaDropUpgradeable {
     ) external initializer initializerERC721A {
         __Imprint_init(name, symbol, allowedSeaDrop);
         if (initialOwner == address(0)) revert ZeroAddress();
-        _transferOwnership(initialOwner);   // OwnableUpgradeable
+        _transferOwnership(initialOwner);
     }
 
     /*═══════════════════════  Edition  API  ══════════════════════*/
-    /// @notice 新しい Edition を作成する。owner 専用。
-    function createEdition(uint64 editionNo, string calldata model)
-        external
-        onlyOwner
-    {
-        if (editionNo == 0) revert InvalidEditionNo();
-        if (bytes(model).length == 0) revert EmptyModel();
-
-        ImprintStorage.Layout storage st = ImprintStorage.layout();
-        // 未使用かチェック（editionNo は一意）
-        if (st.editionHeaders[editionNo].editionNo != 0) revert EditionExists();
-        st.editionHeaders[editionNo] = ImprintStorage.EditionHeader({
-            editionNo:  editionNo,
-            model:      model,
-            timestamp:  uint64(block.timestamp),
-            isSealed:   false
-        });
-        emit EditionCreated(editionNo, model, uint64(block.timestamp));
+    function createEdition(uint64 editionNo, string calldata model) external onlyOwner {
+        ImprintLib.createEditionWithEvent(editionNo, model);
     }
 
-    /// @notice 既存 Edition を封鎖（Seed 追加を禁止）する。owner 専用。
     function sealEdition(uint64 editionNo) external onlyOwner {
-        ImprintStorage.Layout storage st = ImprintStorage.layout();
-        ImprintStorage.EditionHeader storage h = st.editionHeaders[editionNo];
-        if (h.editionNo == 0) revert UnknownEdition();
-        if (h.isSealed) revert AlreadySealed();
-        h.isSealed = true;
-        emit EditionSealed(editionNo);
+        ImprintLib.sealEditionWithEvent(editionNo);
     }
 
     function addSeeds(SeedInput[] calldata inputs) external onlyOwner {
-        ImprintStorage.Layout storage st = ImprintStorage.layout();
-        uint256 n = inputs.length;
-        if (n == 0) revert EmptyInput();
-
-        uint64 batchEdition = inputs[0].editionNo;
-
-        // Batch validation outside loop
-        ImprintStorage.EditionHeader storage hdr = st.editionHeaders[batchEdition];
-        if (hdr.editionNo == 0) revert EditionMissing();
-        if (hdr.isSealed) revert EditionAlreadySealed();
-
-        unchecked {
-            for (uint256 i; i < n; ++i) {
-            SeedInput calldata sIn = inputs[i];
-            if (sIn.editionNo != batchEdition) revert MixedEdition();
-            if (sIn.desc.length == 0) revert EmptyDesc();
-
-            if (st.localIndexTaken[batchEdition][sIn.localIndex]) {
-                revert DuplicateLocalIdx();
-            }
-            st.localIndexTaken[batchEdition][sIn.localIndex] = true;
-
-            uint256 newId = ++st.nextSeedId;
-            st.seeds[newId] = ImprintStorage.ImprintSeed({
-                editionNo:   batchEdition,
-                localIndex:  sIn.localIndex,
-                subjectId:   sIn.subjectId,
-                subjectName: sIn.subjectName,
-                descPtr:     SSTORE2.write(sIn.desc),
-                claimed:     false
-            });
-
-            if (st.firstSeedId[batchEdition] == 0) {
-                st.firstSeedId[batchEdition] = newId;
-            }
-            st.lastSeedId[batchEdition] = newId;
-            }
-        }
-
+        ImprintLib.addSeeds(inputs);
     }
 
-
-    // ──────────────────────────────────────────────
-    //  2) Edition 切替
-    // ──────────────────────────────────────────────
     function setActiveEdition(uint64 editionNo) external onlyOwner {
-        ImprintStorage.Layout storage st = ImprintStorage.layout();
-        
-        // Special case: setting to 0 clears active edition
-        if (editionNo == 0) {
-            st.activeEdition = 0;
-            st.activeCursor = 0;
-            emit ActiveEditionChanged(0);
-            return;
-        }
-
-        ImprintStorage.EditionHeader storage h = st.editionHeaders[editionNo];
-        if (h.editionNo == 0) revert UnknownEdition();
-        if (!h.isSealed) revert EditionNotSealed();
-        if (st.firstSeedId[editionNo] == 0) revert NoSeeds();
-
-        st.activeEdition = editionNo;
-        // 次 mint する seed を先頭にリセット
-        st.activeCursor  = st.firstSeedId[editionNo];
-        emit ActiveEditionChanged(editionNo);
+        ImprintLib.setActiveEditionWithEvent(editionNo);
     }
 
-    // ──────────────────────────────────────────────
-    //  3) SeaDrop からの Mint → Seed Claim
-    // ──────────────────────────────────────────────
-    function mintSeaDrop(address to, uint256 quantity)
-        external
-        override
-        nonReentrant
-    {
+    function mintSeaDrop(address to, uint256 quantity) external override nonReentrant {
         _onlyAllowedSeaDrop(msg.sender);
-        
-        ImprintStorage.Layout storage st = ImprintStorage.layout();
-        if (st.mintPaused) revert MintingPaused();
-
-        uint64 ed = st.activeEdition;
-        if (ed == 0) revert NoActiveEdition();
-
-        uint256 cursor = st.activeCursor;
-        uint256 last   = st.lastSeedId[ed];
-        if (cursor == 0 || cursor + quantity - 1 > last) revert SoldOut();
-
         uint256 firstTokenId = _nextTokenId();
-
-        /*―――― ① メタデータを先に書く ――――*/
-        string memory model = st.editionHeaders[ed].model;
-        unchecked {
-            for (uint256 i; i < quantity; ++i) {
-            uint256 seedId  = cursor + i;
-            uint256 tokenId = firstTokenId + i;
-
-            ImprintStorage.ImprintSeed storage s = st.seeds[seedId];
-            s.claimed = true;
-
-            st.descPtr[tokenId] = s.descPtr;
-            st.meta[tokenId] = ImprintStorage.TokenMeta({
-                editionNo:   ed,
-                localIndex:  s.localIndex,
-                model:       model,
-                subjectName: s.subjectName
-            });
-            }
-        }
-
-        st.activeCursor = cursor + quantity;
-
-        /*―――― ② 安全ミント（外部コール） ――――*/
+        ImprintLib.processMint(to, quantity, firstTokenId);
         _safeMint(to, quantity);
-
-        /*―――― ③ Subject 側へ最新 Imprint を反映 ――――*/
-        if (st.worldCanon != address(0)) {
-            ISubject wc = ISubject(st.worldCanon);
-            unchecked {
-                for (uint256 i; i < quantity; ++i) {
-                    uint256 tokenId = firstTokenId + i;
-                    ImprintStorage.TokenMeta memory tokenMeta = st.meta[tokenId];
-                    // syncFromImprint(subjectName, imprintId, timestamp)を呼び出す
-                    wc.syncFromImprint(tokenMeta.subjectName, tokenId, uint64(block.timestamp));
-                }
-            }
-        }
     }
 
-
-
-    /// @notice Marketplace 表示用 JSON メタデータ
     function tokenURI(uint256 tokenId) public view override returns (string memory) {
         if (!_exists(tokenId)) revert TokenNonexistent();
         if (descriptor == address(0)) revert DescriptorUnset();
         
         (bool ok, bytes memory data) = descriptor.staticcall(
-            abi.encodeWithSelector(
-                IImprintDescriptor.tokenURI.selector, 
-                tokenId
-            )
+            abi.encodeWithSelector(IImprintDescriptor.tokenURI.selector, tokenId)
         );
         if (!ok) revert DescriptorFail();
         return abi.decode(data, (string));
     }
 
-
-
-
-    /*─────────────── WorldCanon integration ───────────────*/
     function setWorldCanon(address worldCanon) external onlyOwner {
-        ImprintStorage.Layout storage st = ImprintStorage.layout();
-        if (st.worldCanon != address(0)) revert WorldCanonAlreadySet();
-        if (worldCanon == address(0)) revert ZeroAddress();
-        st.worldCanon = worldCanon;
-        emit WorldCanonSet(worldCanon);
+        ImprintLib.setWorldCanonWithEvent(worldCanon);
     }
 
-
-    /*─────────────── Mint Pause ───────────────*/
     function setMintPaused(bool paused) external onlyOwner {
-        ImprintStorage.Layout storage st = ImprintStorage.layout();
-        st.mintPaused = paused;
+        ImprintLib.setMintPaused(paused);
     }
 
-
-
-
-
-    /*─────────────── Interface Support ───────────────*/
     function supportsInterface(bytes4 interfaceId) 
-        public 
-        view 
-        virtual 
-        override(ERC721SeaDropUpgradeable) 
-        returns (bool) 
+        public view virtual override(ERC721SeaDropUpgradeable) returns (bool) 
     {
         return 
             interfaceId == type(INonFungibleSeaDropTokenUpgradeable).interfaceId ||
@@ -363,42 +99,38 @@ contract Imprint is ERC721SeaDropUpgradeable {
             super.supportsInterface(interfaceId);
     }
 
-    // Descriptor contract for tokenURI generation
     address public descriptor;
 
-    // Setter for descriptor
     function setDescriptor(address _descriptor) external onlyOwner {
         if (_descriptor == address(0)) revert ZeroAddress();
         descriptor = _descriptor;
     }
 
-    // Minimal getters for ImprintViews compatibility  
+    // Delegate to ImprintLib
     function getEditionHeader(uint64 editionNo) external view returns (ImprintStorage.EditionHeader memory) {
-        return ImprintStorage.layout().editionHeaders[editionNo];
+        return ImprintLib.getEditionHeader(editionNo);
     }
     function getSeed(uint256 seedId) external view returns (ImprintStorage.ImprintSeed memory) {
-        return ImprintStorage.layout().seeds[seedId];
+        return ImprintLib.getSeed(seedId);
     }
     function getTokenMeta(uint256 tokenId) external view returns (ImprintStorage.TokenMeta memory) {
-        return ImprintStorage.layout().meta[tokenId];
+        return ImprintLib.getTokenMeta(tokenId);
     }
     function descPtr(uint256 tokenId) external view returns (address) {
-        return ImprintStorage.layout().descPtr[tokenId];
+        return ImprintLib.getDescPtr(tokenId);
     }
-    function remainingInEdition(uint64 editionNo) external view returns (uint256 remaining) {
-        ImprintStorage.Layout storage st = ImprintStorage.layout();
-        uint256 cursor = st.activeCursor; uint256 last = st.lastSeedId[editionNo];
-        if (cursor == 0 || cursor > last) return 0;
-        unchecked { for (uint256 i = cursor; i <= last; ++i) if (!st.seeds[i].claimed) ++remaining; }
+    function remainingInEdition(uint64 editionNo) external view returns (uint256) {
+        return ImprintLib.getRemainingInEdition(editionNo);
     }
-    function getWorldCanon() external view returns (address) { return ImprintStorage.layout().worldCanon; }
-    function isMintPaused() external view returns (bool) { return ImprintStorage.layout().mintPaused; }
+    function getWorldCanon() external view returns (address) {
+        return ImprintLib.getWorldCanon();
+    }
+    function isMintPaused() external view returns (bool) {
+        return ImprintLib.isMintPaused();
+    }
     function editionSize(uint64 ed) external view returns (uint256) {
-        ImprintStorage.Layout storage st = ImprintStorage.layout();
-        uint256 first = st.firstSeedId[ed]; uint256 last = st.lastSeedId[ed];
-        return (first == 0 || last == 0) ? 0 : last - first + 1;
+        return ImprintLib.getEditionSize(ed);
     }
 
-    uint256[51] private __gap;
-
+    uint256[50] private __gap;
 }

--- a/src-upgradeable/src/ImprintLib.sol
+++ b/src-upgradeable/src/ImprintLib.sol
@@ -1,0 +1,343 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import { SSTORE2 } from "../lib-upgradeable/solmate/src/utils/SSTORE2.sol";
+
+/// @dev owner が Seed を一括登録するときに使う入力フォーマット
+struct SeedInput {
+    uint64  editionNo;      // 紐づく Edition
+    uint16  localIndex;     // Edition 内の連番
+    uint256 subjectId;      // Subject tokenId（まだ使わなければ 0 でも可）
+    string  subjectName;    // 表示用名
+    bytes   desc;           // SVG 本文（UTF-8）最大 280Byte 推奨
+}
+
+/// ──────────────────────────────────────────────────────────────
+///  ImprintStorage  ── World Canon / Imprint  固定ストレージ
+/// ──────────────────────────────────────────────────────────────
+library ImprintStorage {
+    /*═════════ ① 不変データ構造 ═════════*/
+
+    /// Edition 毎のヘッダー
+    struct EditionHeader {
+        uint64  editionNo;   // 連番（＝キー）
+        string  model;       // 例 "GPT-4o"
+        uint64  timestamp;   // block.timestamp (UTC 秒)
+        bool    isSealed;      // true なら Seed 追加不可
+    }
+
+    /// SeaDrop ミント前にプレ登録する "Seed"
+    struct ImprintSeed {
+        uint64   editionNo;      // 紐づく Edition
+        uint16   localIndex;     // Edition 内 index
+        uint256  subjectId;      // Subject tokenId
+        string   subjectName;    // Subject 名
+        address  descPtr;        // SSTORE2 ポインタ
+        bool     claimed;        // mint 済みか
+    }
+
+    /// Mint 後、Subject 側から呼ばれるときに使う最終メタ
+    struct TokenMeta {
+        uint64  editionNo;
+        uint16  localIndex;      // Edition 内 index
+        string  model;
+        string  subjectName;
+    }
+
+    /*═════════ ② Diamond-Layout ═════════*/
+
+    struct Layout {
+        /* --- Finalized Imprint (tokenId 同値) --- */
+        mapping(uint256 => address)     descPtr;   // slot offset 0
+        mapping(uint256 => TokenMeta)   meta;      // slot offset 1
+
+        /* --- Edition & Seed --- */
+        mapping(uint64  => EditionHeader) editionHeaders;   // slot offset 2
+        mapping(uint256 => ImprintSeed)   seeds;            // slot offset 3
+        uint256  nextSeedId;                                // slot offset 4
+
+        /* --- Sale --- */
+        uint64  activeEdition;       // 現在販売中の Edition
+        uint256 activeCursor;        // その Edition 内で次に配布する seedId
+        mapping(uint64 => uint256) firstSeedId;   // editionNo -> 先頭 seedId
+        mapping(uint64 => uint256) lastSeedId;    // editionNo -> 末尾 seedId
+        mapping(uint64 => mapping(uint16 => bool)) localIndexTaken;
+
+        /* --- Globals --- */
+        address  worldCanon;   // Subject コントラクト (set once)
+        bool     mintPaused;   // Mint一時停止フラグ
+    }
+
+    /*═════════ ③ 取得ヘルパ ═════════*/
+
+    bytes32 internal constant STORAGE_SLOT =
+        keccak256("worldcanon.imprint.storage.v0");
+
+    function layout() internal pure returns (Layout storage l) {
+        bytes32 slot = STORAGE_SLOT;
+        assembly { l.slot := slot }
+    }
+}
+
+// Custom errors for gas optimization
+error ZeroAddress();
+error InvalidEditionNo();
+error EmptyModel();
+error EditionExists();
+error UnknownEdition();
+error AlreadySealed();
+error EmptyInput();
+error MixedEdition();
+error EmptyDesc();
+error EditionMissing();
+error EditionAlreadySealed();
+error DuplicateLocalIdx();
+error EditionNotSealed();
+error NoSeeds();
+error MintingPaused();
+error NoActiveEdition();
+error SoldOut();
+error TokenNonexistent();
+error DescriptorUnset();
+error DescriptorFail();
+error WorldCanonAlreadySet();
+
+library ImprintLib {
+    using ImprintStorage for ImprintStorage.Layout;
+
+    event EditionCreated(uint64 indexed editionNo, string model, uint64 timestamp);
+    event EditionSealed(uint64 indexed editionNo);
+    event ActiveEditionChanged(uint64 indexed newEdition);
+    event WorldCanonSet(address indexed worldCanon);
+
+    function createEditionWithEvent(uint64 editionNo, string calldata model) external {
+        if (editionNo == 0) revert InvalidEditionNo();
+        if (bytes(model).length == 0) revert EmptyModel();
+
+        ImprintStorage.Layout storage st = ImprintStorage.layout();
+        if (st.editionHeaders[editionNo].editionNo != 0) revert EditionExists();
+        
+        uint64 timestamp = uint64(block.timestamp);
+        st.editionHeaders[editionNo] = ImprintStorage.EditionHeader({
+            editionNo:  editionNo,
+            model:      model,
+            timestamp:  timestamp,
+            isSealed:   false
+        });
+        
+        emit EditionCreated(editionNo, model, timestamp);
+    }
+
+    function sealEditionWithEvent(uint64 editionNo) external {
+        ImprintStorage.Layout storage st = ImprintStorage.layout();
+        ImprintStorage.EditionHeader storage h = st.editionHeaders[editionNo];
+        if (h.editionNo == 0) revert UnknownEdition();
+        if (h.isSealed) revert AlreadySealed();
+        h.isSealed = true;
+        
+        emit EditionSealed(editionNo);
+    }
+
+    function setActiveEditionWithEvent(uint64 editionNo) external {
+        ImprintStorage.Layout storage st = ImprintStorage.layout();
+        
+        if (editionNo == 0) {
+            st.activeEdition = 0;
+            st.activeCursor = 0;
+            emit ActiveEditionChanged(0);
+            return;
+        }
+
+        ImprintStorage.EditionHeader storage h = st.editionHeaders[editionNo];
+        if (h.editionNo == 0) revert UnknownEdition();
+        if (!h.isSealed) revert EditionNotSealed();
+        if (st.firstSeedId[editionNo] == 0) revert NoSeeds();
+
+        st.activeEdition = editionNo;
+        st.activeCursor  = st.firstSeedId[editionNo];
+        
+        emit ActiveEditionChanged(editionNo);
+    }
+
+    function setWorldCanonWithEvent(address worldCanon) external {
+        ImprintStorage.Layout storage st = ImprintStorage.layout();
+        if (st.worldCanon != address(0)) revert WorldCanonAlreadySet();
+        if (worldCanon == address(0)) revert ZeroAddress();
+        st.worldCanon = worldCanon;
+        
+        emit WorldCanonSet(worldCanon);
+    }
+
+    function processMint(address /*to*/, uint256 quantity, uint256 firstTokenId) external returns (uint256) {
+        ImprintStorage.Layout storage st = ImprintStorage.layout();
+        if (st.mintPaused) revert MintingPaused();
+
+        uint64 ed = st.activeEdition;
+        if (ed == 0) revert NoActiveEdition();
+
+        uint256 cursor = st.activeCursor;
+        uint256 last = st.lastSeedId[ed];
+        if (cursor == 0 || cursor + quantity - 1 > last) revert SoldOut();
+
+        string memory model = st.editionHeaders[ed].model;
+        address worldCanon = st.worldCanon;
+        
+        unchecked {
+            for (uint256 i; i < quantity; ++i) {
+                uint256 seedId = cursor + i;
+                uint256 tokenId = firstTokenId + i;
+                ImprintStorage.ImprintSeed storage s = st.seeds[seedId];
+                s.claimed = true;
+                st.descPtr[tokenId] = s.descPtr;
+                st.meta[tokenId] = ImprintStorage.TokenMeta({
+                    editionNo: ed,
+                    localIndex: s.localIndex,
+                    model: model,
+                    subjectName: s.subjectName
+                });
+                
+                // Sync with Subject directly here
+                if (worldCanon != address(0)) {
+                    (bool success,) = worldCanon.call(
+                        abi.encodeWithSignature(
+                            "syncFromImprint(string,uint256,uint64)",
+                            s.subjectName,
+                            tokenId,
+                            uint64(block.timestamp)
+                        )
+                    );
+                    // Ignore failures to prevent mint blocking
+                    success;
+                }
+            }
+        }
+
+        st.activeCursor = cursor + quantity;
+        
+        return firstTokenId;
+    }
+
+    function createEdition(uint64 editionNo, string calldata model) external {
+        if (editionNo == 0) revert InvalidEditionNo();
+        if (bytes(model).length == 0) revert EmptyModel();
+
+        ImprintStorage.Layout storage st = ImprintStorage.layout();
+        if (st.editionHeaders[editionNo].editionNo != 0) revert EditionExists();
+        st.editionHeaders[editionNo] = ImprintStorage.EditionHeader({
+            editionNo:  editionNo,
+            model:      model,
+            timestamp:  uint64(block.timestamp),
+            isSealed:   false
+        });
+    }
+
+    function sealEdition(uint64 editionNo) external {
+        ImprintStorage.Layout storage st = ImprintStorage.layout();
+        ImprintStorage.EditionHeader storage h = st.editionHeaders[editionNo];
+        if (h.editionNo == 0) revert UnknownEdition();
+        if (h.isSealed) revert AlreadySealed();
+        h.isSealed = true;
+    }
+
+    function addSeeds(SeedInput[] calldata inputs) external {
+        ImprintStorage.Layout storage st = ImprintStorage.layout();
+        uint256 n = inputs.length;
+        if (n == 0) revert EmptyInput();
+
+        uint64 batchEdition = inputs[0].editionNo;
+        ImprintStorage.EditionHeader storage hdr = st.editionHeaders[batchEdition];
+        if (hdr.editionNo == 0) revert EditionMissing();
+        if (hdr.isSealed) revert EditionAlreadySealed();
+
+        unchecked {
+            for (uint256 i; i < n; ++i) {
+                SeedInput calldata sIn = inputs[i];
+                if (sIn.editionNo != batchEdition) revert MixedEdition();
+                if (sIn.desc.length == 0) revert EmptyDesc();
+                if (st.localIndexTaken[batchEdition][sIn.localIndex]) revert DuplicateLocalIdx();
+                
+                st.localIndexTaken[batchEdition][sIn.localIndex] = true;
+                uint256 newId = ++st.nextSeedId;
+                st.seeds[newId] = ImprintStorage.ImprintSeed({
+                    editionNo:   batchEdition,
+                    localIndex:  sIn.localIndex,
+                    subjectId:   sIn.subjectId,
+                    subjectName: sIn.subjectName,
+                    descPtr:     SSTORE2.write(sIn.desc),
+                    claimed:     false
+                });
+
+                if (st.firstSeedId[batchEdition] == 0) {
+                    st.firstSeedId[batchEdition] = newId;
+                }
+                st.lastSeedId[batchEdition] = newId;
+            }
+        }
+    }
+
+    function setActiveEdition(uint64 editionNo) external {
+        ImprintStorage.Layout storage st = ImprintStorage.layout();
+        
+        if (editionNo == 0) {
+            st.activeEdition = 0;
+            st.activeCursor = 0;
+            return;
+        }
+
+        ImprintStorage.EditionHeader storage h = st.editionHeaders[editionNo];
+        if (h.editionNo == 0) revert UnknownEdition();
+        if (!h.isSealed) revert EditionNotSealed();
+        if (st.firstSeedId[editionNo] == 0) revert NoSeeds();
+
+        st.activeEdition = editionNo;
+        st.activeCursor  = st.firstSeedId[editionNo];
+    }
+
+    // Getter functions
+    function getEditionHeader(uint64 editionNo) external view returns (ImprintStorage.EditionHeader memory) {
+        return ImprintStorage.layout().editionHeaders[editionNo];
+    }
+
+    function getSeed(uint256 seedId) external view returns (ImprintStorage.ImprintSeed memory) {
+        return ImprintStorage.layout().seeds[seedId];
+    }
+
+    function getTokenMeta(uint256 tokenId) external view returns (ImprintStorage.TokenMeta memory) {
+        return ImprintStorage.layout().meta[tokenId];
+    }
+
+    function getDescPtr(uint256 tokenId) external view returns (address) {
+        return ImprintStorage.layout().descPtr[tokenId];
+    }
+
+    function getRemainingInEdition(uint64 editionNo) external view returns (uint256 remaining) {
+        ImprintStorage.Layout storage st = ImprintStorage.layout();
+        uint256 cursor = st.activeCursor; 
+        uint256 last = st.lastSeedId[editionNo];
+        if (cursor == 0 || cursor > last) return 0;
+        unchecked { 
+            for (uint256 i = cursor; i <= last; ++i) {
+                if (!st.seeds[i].claimed) ++remaining;
+            }
+        }
+    }
+
+    function getWorldCanon() external view returns (address) {
+        return ImprintStorage.layout().worldCanon;
+    }
+
+    function isMintPaused() external view returns (bool) {
+        return ImprintStorage.layout().mintPaused;
+    }
+
+    function getEditionSize(uint64 ed) external view returns (uint256) {
+        ImprintStorage.Layout storage st = ImprintStorage.layout();
+        uint256 first = st.firstSeedId[ed]; 
+        uint256 last = st.lastSeedId[ed];
+        return (first == 0 || last == 0) ? 0 : last - first + 1;
+    }
+
+    function setMintPaused(bool paused) external {
+        ImprintStorage.layout().mintPaused = paused;
+    }
+} 

--- a/test/foundry/Imprint.t.sol
+++ b/test/foundry/Imprint.t.sol
@@ -3,7 +3,8 @@ pragma solidity ^0.8.17;
 
 import { TestHelper } from "test/foundry/utils/TestHelper.sol";
 
-import { Imprint, ImprintStorage, SeedInput, DescMissing, DescriptorFail, MintingPaused, UnknownEdition, ZeroAddress, EditionExists, AlreadySealed, WorldCanonAlreadySet, NoActiveEdition } from "../../src-upgradeable/src/Imprint.sol";
+import { Imprint } from "../../src-upgradeable/src/Imprint.sol";
+import { ImprintStorage, SeedInput, ZeroAddress, InvalidEditionNo, EmptyModel, EditionExists, UnknownEdition, AlreadySealed, EmptyInput, MixedEdition, EmptyDesc, EditionMissing, EditionAlreadySealed, DuplicateLocalIdx, EditionNotSealed, NoSeeds, MintingPaused, NoActiveEdition, SoldOut, TokenNonexistent, DescriptorUnset, DescriptorFail, WorldCanonAlreadySet } from "../../src-upgradeable/src/ImprintLib.sol";
 import { ImprintViews } from "../../src-upgradeable/src/ImprintViews.sol";
 import { ImprintDescriptor } from "../../src-upgradeable/src/ImprintDescriptor.sol";
 import { IImprintDescriptor } from "../../src-upgradeable/src/interfaces/IImprintDescriptor.sol";


### PR DESCRIPTION
- Imprint.solの重いロジックをImprintLib.solに移行
  - libraryにすると別のコントラクトの扱いになるので、ファイルサイズを削減できる
  - aaveもdepositやborrowの処理はlibraryに置いている
    - https://github.com/aave/aave-v3-core/blob/master/contracts/protocol/pool/Pool.sol
- Imprint.solのmax_optimizer_runsを200から100に変更
 - runsを小さくするのほどサイズは小さくなるが、実行のガス代が上がってしまうので、できるだけ下げないように100に設定した
 
 
<img width="1448" alt="Screenshot 2025-06-01 at 22 15 09" src="https://github.com/user-attachments/assets/99cdded2-4d0e-457d-9cb2-3c8b55447d4b" />
